### PR TITLE
Add missing rancher `api_url` in cred file example

### DIFF
--- a/examples/providerconfig/secret.yaml.tmpl
+++ b/examples/providerconfig/secret.yaml.tmpl
@@ -7,6 +7,7 @@ type: Opaque
 stringData:
   credentials: |
     {
+      "api_url": "https://rancher.example.com"
       "access_key": "admin",
       "secret_key": "t0ps3cr3t11"
     }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR adds the missing `api_url` field in the credentials file.

`api_url` controls the target Rancher cluster to work with.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A

[contribution process]: https://git.io/fj2m9
